### PR TITLE
Update App Store link and remove Google Play reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,14 +65,7 @@
         <p>Take control of your finances with our intuitive budget management app. Track expenses, set goals, and achieve financial freedom.</p>
         
         <div class="app-store-badges">
-            <!-- Store linklerini uygulamanız yayınlandığında buraya ekleyeceksiniz -->
-            <span class="badge coming-soon">📱 Coming Soon to App Store</span>
-            <span class="badge coming-soon">🤖 Coming Soon to Google Play</span>
-            
-            <!-- Yayınlandıktan sonra şu şekilde olacak:
-            <a href="https://apps.apple.com/app/budget-friendly/idXXXXXXXX" class="badge">📱 Download on App Store</a>
-            <a href="https://play.google.com/store/apps/details?id=com.berk3335.budgetfriendly" class="badge">🤖 Get it on Google Play</a>
-            -->
+            <a href="https://apps.apple.com/tr/app/budget-friendly/id6746421792?l=tr" class="badge">📱 Download on App Store</a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Changes Made

- ✅ **Removed Google Play Store reference** (since app is only available on App Store)
- ✅ **Updated App Store link** to the correct live URL: https://apps.apple.com/tr/app/budget-friendly/id6746421792?l=tr
- ✅ **Removed "Coming Soon" message** and made App Store link active
- ✅ **Simplified the layout** to show only the available App Store option

## Impact

- Users can now directly download the app from the App Store
- No confusion about Google Play availability
- Clean, focused user experience